### PR TITLE
debian: A few fixes to make it build properly in a chroot

### DIFF
--- a/debian/Cargo.toml.append
+++ b/debian/Cargo.toml.append
@@ -2,3 +2,4 @@
 
 [patch.crates-io]
 systemd = { path = "vendor-patched/systemd" }
+syn = { path = "vendor/syn" }

--- a/debian/README.source
+++ b/debian/README.source
@@ -1,12 +1,24 @@
-Since Debian Stretch does not have a complete Rust packaging environment
-yet, we build the Debian package by first using "cargo vendor" to
-downlooad the dependencies. To run this automatically and set things up,
-run
+Because Debian Stretch does not have a complete Rust packaging
+environment yet, we build the Debian package by first using "cargo
+vendor" to downlooad the dependencies. To run this automatically and set
+things up, manually run
 
     debian/rules vendor
 
-You can then build with dpkg-buildpackage (or commit and build with gbp
-buildpackage if you use that). The debian/rules vendor target also
-patches around an issue where the current versiojn of rustc in
-Stretch/Buster fails to compile the latest version of the "systemd"
-crate.
+in an environment with internet accesss.
+
+You can commit the resulting changes to your local clone, if you build
+packages in CI from git sources, or you can build a source package. (You
+may want to first run "debian/rules build clean" to trigger a small
+change to Cargo.toml, too.) The resulting git repo / source package will
+build like an ordinary Debian package, without needing to access the
+internet.
+
+The "debian/rules vendor" target does the following:
+ - Runs "cargo vendor" and sets up Cargo configuration
+ - Works around an issue where the current version of rustc in
+   Stretch/Buster fails to compile the latest version of the "systemd"
+   crate
+ - Works around an issue where the "syn" crate includes a .gitignore
+   file, which is automatically ignored by dpkg-source when building the
+   source package

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-nsncd (0.1) unstable; urgency=medium
+nsncd (1.0) unstable; urgency=medium
 
   * Initial release.
 
- -- Geoffrey Thomas <geofft@twosigma.com>  Tue, 06 Oct 2020 14:35:08 -0400
+ -- Geoffrey Thomas <geofft@twosigma.com>  Tue, 19 Jan 2021 20:41:41 -0500

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: nsncd
 Section: misc
 Priority: optional
 Maintainer: Geoffrey Thomas <geofft@twosigma.com>
-Build-Depends: debhelper (>= 12), cargo, libsystemd-dev
+Build-Depends: debhelper (>= 12), cargo, libsystemd-dev, pkg-config
 Standards-Version: 3.9.8
 Homepage: https://github.com/twosigma/nsncd
 VCS-Git: https://github.com/twosigma/nsncd -b debian


### PR DESCRIPTION
- Add missing pkg-config dep so libsystemd_sys is happy
- Use [replace] mechanism to work around dpkg-source not putting
  .gitignore files in the source tarball
- Expand docs a bit
- Bump version number to 1.0 (to supersede previous internal builds)