### PR TITLE
Bump version to 1.0 and fix up Debian packaging a bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nsncd"
-version = "0.1.0"
+version = "1.0.0"
 authors = [
     "Ben Linsay <ben.linsay@twosigma.com>",
     "Geoffrey Thomas <geoffrey.thomas@twosigma.com>",

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,0 +1,6 @@
+.debhelper/
+debhelper-build-stamp
+files
+*.substvars
+*.debhelper
+nsncd/

--- a/debian/Cargo.toml.append
+++ b/debian/Cargo.toml.append
@@ -2,3 +2,4 @@
 
 [patch.crates-io]
 systemd = { path = "vendor-patched/systemd" }
+syn = { path = "vendor/syn" }

--- a/debian/README.source
+++ b/debian/README.source
@@ -1,12 +1,24 @@
-Since Debian Stretch does not have a complete Rust packaging environment
-yet, we build the Debian package by first using "cargo vendor" to
-downlooad the dependencies. To run this automatically and set things up,
-run
+Because Debian Stretch does not have a complete Rust packaging
+environment yet, we build the Debian package by first using "cargo
+vendor" to download the dependencies. To run this automatically and set
+things up, manually run
 
     debian/rules vendor
 
-You can then build with dpkg-buildpackage (or commit and build with gbp
-buildpackage if you use that). The debian/rules vendor target also
-patches around an issue where the current versiojn of rustc in
-Stretch/Buster fails to compile the latest version of the "systemd"
-crate.
+in an environment with internet accesss.
+
+You can commit the resulting changes to your local clone, if you build
+packages in CI from git sources, or you can build a source package. (You
+may want to first run "debian/rules build clean" to trigger a small
+change to Cargo.toml, too.) The resulting git repo / source package will
+build like an ordinary Debian package, without needing to access the
+internet.
+
+The "debian/rules vendor" target does the following:
+ - Runs "cargo vendor" and sets up Cargo configuration
+ - Works around an issue where the current version of rustc in
+   Stretch/Buster fails to compile the latest version of the "systemd"
+   crate
+ - Works around an issue where the "syn" crate includes a .gitignore
+   file, which is automatically ignored by dpkg-source when building the
+   source package

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-nsncd (0.1) unstable; urgency=medium
+nsncd (1.0) unstable; urgency=medium
 
   * Initial release.
 
- -- Geoffrey Thomas <geofft@twosigma.com>  Tue, 06 Oct 2020 14:35:08 -0400
+ -- Geoffrey Thomas <geofft@twosigma.com>  Tue, 19 Jan 2021 20:41:41 -0500

--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,11 @@ Source: nsncd
 Section: misc
 Priority: optional
 Maintainer: Geoffrey Thomas <geofft@twosigma.com>
-Build-Depends: debhelper (>= 12), cargo, libsystemd-dev
+Build-Depends: debhelper (>= 12), cargo, libsystemd-dev, pkg-config
 Standards-Version: 3.9.8
 Homepage: https://github.com/twosigma/nsncd
-VCS-Git: https://github.com/twosigma/nsncd -b debian
-VCS-Browser: https://github.com/twosigma/nsncd/tree/debian
+VCS-Git: https://github.com/twosigma/nsncd
+VCS-Browser: https://github.com/twosigma/nsncd
 XC-Multidist: yes
 Rules-Requires-Root: no
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,4 +3,18 @@ Source: https://github.com/twosigma/nsncd
 
 Files: *
 Copyright: 2020 Two Sigma Open Source, LLC
-License: Apache-2
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the full text of the Apache License 2.0 can be found
+ in the file `/usr/share/common-licenses/Apache-2.0'.

--- a/debian/rules
+++ b/debian/rules
@@ -15,3 +15,4 @@ vendor:
 	find vendor-patched/systemd -name .cargo-checksum.json -delete
 	find vendor-patched/systemd -name \*.rs -exec sed -i 's/use \(\(..*\)::.*\) as \2/use ::\1 as \2/' {} +
 	cat debian/Cargo.toml.append >> Cargo.toml
+	echo 'nsncd: source-is-missing vendor/*' > debian/source/lintian-overrides


### PR DESCRIPTION
- Add missing pkg-config dep so libsystemd_sys is happy
- Use [patch] mechanism to work around dpkg-source not putting
  .gitignore files in the source tarball
- Expand docs a bit
- Avoid Lintian errors (fix d/copyright and ignore missing sources i
  vendor/)
- Bump version number to 1.0 (to supersede previous internal builds)