### PR TITLE
bump Cargo.lock version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "nsncd"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "atoi",


### PR DESCRIPTION
We bumped Cargo.toml in #5 but didn't update Cargo.lock. Bump it to match.