### PR TITLE
handle keys with internal nuls and ignore systemd

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -15,7 +15,7 @@
  */
 
 use std::convert::TryInto;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::os::unix::ffi::OsStrExt;
 
 use anyhow::{Context, Result};
@@ -42,21 +42,25 @@ where
     debug!(log, "handling request"; "request" => ?request);
     match request.ty {
         RequestType::GETPWBYUID => {
-            let uid = atoi::<u32>(request.key.to_bytes()).context("invalid uid string")?;
+            let key = CStr::from_bytes_with_nul(request.key)?;
+            let uid = atoi::<u32>(key.to_bytes()).context("invalid uid string")?;
             let user = User::from_uid(Uid::from_raw(uid))?;
             send_user(log, user, send_slice)
         }
         RequestType::GETPWBYNAME => {
-            let user = User::from_name(request.key.to_str()?)?;
+            let key = CStr::from_bytes_with_nul(request.key)?;
+            let user = User::from_name(key.to_str()?)?;
             send_user(log, user, send_slice)
         }
         RequestType::GETGRBYGID => {
-            let gid = atoi::<u32>(request.key.to_bytes()).context("invalid gid string")?;
+            let key = CStr::from_bytes_with_nul(request.key)?;
+            let gid = atoi::<u32>(key.to_bytes()).context("invalid gid string")?;
             let group = Group::from_gid(Gid::from_raw(gid))?;
             send_group(log, group, send_slice)
         }
         RequestType::GETGRBYNAME => {
-            let group = Group::from_name(request.key.to_str()?)?;
+            let key = CStr::from_bytes_with_nul(request.key)?;
+            let group = Group::from_name(key.to_str()?)?;
             send_group(log, group, send_slice)
         }
         RequestType::GETHOSTBYADDR

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -23,7 +23,6 @@
 //! need to read both.
 
 use std::convert::TryInto;
-use std::ffi::CStr;
 use std::mem::size_of;
 
 use anyhow::{ensure, Context, Result};
@@ -77,7 +76,7 @@ pub enum RequestType {
 #[derive(Debug)]
 pub struct Request<'a> {
     pub ty: RequestType,
-    pub key: &'a CStr,
+    pub key: &'a [u8],
 }
 
 impl<'a> Request<'a> {
@@ -96,8 +95,10 @@ impl<'a> Request<'a> {
         let key_end = (12 + key_len).try_into()?;
         ensure!(buf.len() >= key_end, "request body too small");
 
-        let key = CStr::from_bytes_with_nul(&buf[12..key_end])?;
-        Ok(Request { ty, key })
+        Ok(Request {
+            ty,
+            key: &buf[12..key_end],
+        })
     }
 }
 


### PR DESCRIPTION
Deserialize keys that have nuls in them (because these might be ip
addresses), handle nul-terminated strings higher up when we know what
kind of request it is.

Don't use systemd socket activation becuase startup ordering is weird.

fixes #7