### PR TITLE
use rust-analyzer support from matklad.rust-analyzer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
 		// VS Code don't watch files under ./target
 		"files.watcherExclude": {
 			"**/target/**": true
-		}
+		},
+		"rust-client.engine": "rust-analyzer"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
@@ -24,8 +25,7 @@
 		"vadimcn.vscode-lldb",
 		"mutantdino.resourcemonitor",
 		"stkb.rewrap",
-		"github.vscode-pull-request-github",
-		"matklad.rust-analyzer"
+		"github.vscode-pull-request-github"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,13 +14,12 @@
 		// VS Code don't watch files under ./target
 		"files.watcherExclude": {
 			"**/target/**": true
-		},
-		"rust-client.engine": "rust-analyzer"
+		}
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"rust-lang.rust",
+		"matklad.rust-analyzer",
 		"bungcip.better-toml",
 		"vadimcn.vscode-lldb",
 		"mutantdino.resourcemonitor",


### PR DESCRIPTION
The main Rust extension has support for rust-analyzer, but I tried it and it's currently broken. The other extension `matklad.rust-analyzer` says it's in alpha and is incompatible with the main rust extension, but has the merit that it actually works.