### PR TITLE
use sd-notify to signal readyness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "once_cell",
+ "sd-notify",
  "slog",
  "slog-async",
  "slog-term",
@@ -646,6 +647,12 @@ name = "scratch"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
+name = "sd-notify"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621e3680f3e07db4c9c2c3fb07c6223ab2fab2e54bd3c04c3ae037990f428c32"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "sd-notify"
-version = "0.4.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621e3680f3e07db4c9c2c3fb07c6223ab2fab2e54bd3c04c3ae037990f428c32"
+checksum = "0cd08a21f852bd2fe42e3b2a6c76a0db6a95a5b5bd29c0521dd0b30fa1712ec8"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ crossbeam-channel = "^0.5"
 nix = "^0.21.2"
 num-derive = "^0.3"
 num-traits = "^0.2"
+sd-notify = "0.4.1"
 # Indirect dependency, constrained for MSRV
 once_cell = "~1.14"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ crossbeam-channel = "^0.5"
 nix = "^0.21.2"
 num-derive = "^0.3"
 num-traits = "^0.2"
-sd-notify = "0.4.1"
+# Hold at 0.3: 0.4 MSRV is too new
+sd-notify = "~0.3"
 # Indirect dependency, constrained for MSRV
 once_cell = "~1.14"
 

--- a/nsncd.service
+++ b/nsncd.service
@@ -18,6 +18,7 @@ Description=name-service non-caching daemon
 [Service]
 ExecStart=/usr/lib/nsncd
 Restart=always
+Type=notify
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Provide a way to signal nsncd has successfully started up, and is ready to accept connections.

A more reliable way would be to only signal this once at least one worker has started up, but this is good enough (tm) for now.

This can be used in a systemd.service file with Type=notify.