### PR TITLE
Implement the GETAI operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +340,7 @@ dependencies = [
  "atoi",
  "criterion",
  "crossbeam-channel",
+ "dns-lookup",
  "nix",
  "num-derive",
  "num-traits",
@@ -592,6 +605,16 @@ dependencies = [
  "term",
  "thread_local",
  "time",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ crossbeam-channel = "^0.5"
 nix = "^0.21.2"
 num-derive = "^0.3"
 num-traits = "^0.2"
+dns-lookup = "^1.0.8"
 
 [dev-dependencies]
 criterion = "^0.3"


### PR DESCRIPTION
We implement the GETAI (aka. get address info) operation. Most of the glibc applications will rely on this operation to perform the hostname -> addrs resolutions.

We add some unit tests checking that we're correctly serializing the address info header and its payload. The expected data used in these tests has been extracted from various Nscd socket dumps. We also add an integration test checking that getaddrinfo is able to resolve localhost.

The Nix crate we rely on for the glibc FFI bindings does not wrap getaddrinfo yet. We had to pull the `dns-lookup` package to get those bindings.

Part of #37.

Note: on top of the automated tests, this PR has also been manually tested via a test VM.