### PR TITLE
implement GETHOSTBY{ADDR,NAME}[v6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,9 +291,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "log"
@@ -328,6 +340,7 @@ dependencies = [
  "atoi",
  "criterion",
  "crossbeam-channel",
+ "dns-lookup",
  "nix",
  "num-derive",
  "num-traits",
@@ -592,6 +605,16 @@ dependencies = [
  "term",
  "thread_local",
  "time",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ crossbeam-channel = "^0.5"
 nix = "^0.21.2"
 num-derive = "^0.3"
 num-traits = "^0.2"
+dns-lookup = "1.0.8"
 
 [dev-dependencies]
 criterion = "^0.3"

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -16,9 +16,10 @@
 
 use std::convert::TryInto;
 use std::ffi::{CStr, CString};
+use std::net::IpAddr;
 use std::os::unix::ffi::OsStrExt;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use atoi::atoi;
 use nix::unistd::{getgrouplist, Gid, Group, Uid, User};
 use slog::{debug, error, Logger};
@@ -230,6 +231,129 @@ fn serialize_initgroups(groups: Vec<Gid>) -> Result<Vec<u8>> {
     }
 
     Ok(result)
+}
+
+pub struct Host {
+    pub addresses: Vec<std::net::IpAddr>,
+    // aliases is unused so far
+    pub hostname: String,
+}
+
+/// Send a gethostby{addr,name}{,v6} entry back to the client,
+/// or a response indicating the lookup failed.
+fn serialize_host(log: &slog::Logger, host: Result<Option<Host>>) -> Vec<u8> {
+    let result = || {
+        match host {
+            Ok(Some(host)) => {
+                // Loop over all addresses.
+                // Serialize them into a slice, which is used later in the payload.
+                // Take note of the number of addresses (by AF).
+                let mut num_v4 = 0;
+                let mut num_v6 = 0;
+                let mut buf_addrs = vec![];
+
+                for address in host.addresses {
+                    match address {
+                        IpAddr::V4(ip4) => {
+                            num_v4 += 1;
+                            for octet in ip4.octets() {
+                                buf_addrs.push(octet)
+                            }
+                        }
+                        IpAddr::V6(ip6) => {
+                            num_v6 += 1;
+                            for octet in ip6.octets() {
+                                buf_addrs.push(octet)
+                            }
+                        }
+                    }
+                }
+
+                // this can only ever express one address family
+                if num_v4 != 0 && num_v6 != 0 {
+                    bail!("unable to serialize mixed AF")
+                }
+
+                let num_addrs = num_v4 + num_v6;
+
+                let hostname_c_string_bytes =
+                    CString::new(host.hostname.clone())?.into_bytes_with_nul();
+                let hostname_c_string_len = hostname_c_string_bytes.len();
+
+                let header = protocol::HstResponseHeader {
+                    version: protocol::VERSION,
+                    found: 1 as i32,
+                    h_name_len: hostname_c_string_len as i32,
+                    h_aliases_cnt: 0 as i32,
+                    h_addrtype: if num_v4 != 0 {
+                        nix::sys::socket::AddressFamily::Inet as i32
+                    } else {
+                        nix::sys::socket::AddressFamily::Inet6 as i32
+                    },
+                    h_length: if num_v4 != 0 { 4 as i32 } else { 16 as i32 },
+                    h_addr_list_cnt: num_addrs as i32,
+                    error: 0,
+                };
+
+                let total_len = 4 * 8 + hostname_c_string_len as i32 + buf_addrs.len() as i32;
+                let mut buf = Vec::with_capacity(total_len as usize);
+
+                // add header
+                buf.extend_from_slice(header.as_slice());
+
+                // add hostname
+                buf.extend_from_slice(&hostname_c_string_bytes);
+
+                // add serialized addresses from buf_addrs
+                buf.extend_from_slice(buf_addrs.as_slice());
+
+                debug_assert_eq!(buf.len() as i32, total_len);
+
+                Ok(buf)
+            }
+            Ok(None) => {
+                let header = protocol::HstResponseHeader {
+                    version: protocol::VERSION,
+                    found: 0,
+                    h_name_len: 0,
+                    h_aliases_cnt: 0,
+                    h_addrtype: -1 as i32,
+                    h_length: -1 as i32,
+                    h_addr_list_cnt: 0,
+                    error: protocol::H_ERRNO_HOST_NOT_FOUND as i32,
+                };
+
+                let mut buf = Vec::with_capacity(4 * 8);
+                buf.extend_from_slice(header.as_slice());
+                Ok(buf)
+            }
+            Err(e) => {
+                // pass along error
+                Err(e)
+            }
+        }
+    };
+
+    match result() {
+        Ok(res) => res,
+        Err(e) => {
+            error!(log, "parsing request"; "err" => %e);
+            let header = protocol::HstResponseHeader {
+                version: protocol::VERSION,
+                found: 0,
+                h_name_len: 0,
+                h_aliases_cnt: 0,
+                h_addrtype: -1 as i32,
+                h_length: -1 as i32,
+                h_addr_list_cnt: protocol::H_ERRNO_NETDB_INTERNAL as i32,
+                error: 0,
+            };
+
+            let mut buf = Vec::with_capacity(4 * 8);
+            buf.extend_from_slice(header.as_slice());
+            buf
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -35,6 +35,12 @@ use nix::libc::{c_int, gid_t, uid_t};
 /// of each message header.
 pub const VERSION: i32 = 2;
 
+/// Errors used in HstResponseHeader struct
+pub const H_ERRNO_NETDB_INTERNAL: i32 = -1;
+pub const H_ERRNO_HOST_NOT_FOUND: i32 = 1; // Authoritative Answer Host not found.
+#[allow(dead_code)]
+pub const H_ERRNO_TRY_AGAIN: i32 = 2; // Non-Authoritative Host not found
+
 /// Available services. This enum describes all service types the nscd protocol
 /// knows about, though we only implement `GETPW*`, `GETGR*`, and `INITGROUPS`.
 #[derive(Debug, FromPrimitive)]


### PR DESCRIPTION
This adds support for the following request types:

 - GETHOSTBYADDR
 - GETHOSTBYADDRv6
 - GETHOSTBYNAME
 - GETHOSTBYNAMEv6

Part of #37.