### PR TITLE
Build in Debian 10 container

### DIFF
--- a/.github/workflows/rust-debian10.yml
+++ b/.github/workflows/rust-debian10.yml
@@ -1,0 +1,26 @@
+name: "Debian 10"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    container: debian:10
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        apt-get update
+        apt-get -y install build-essential dpkg-dev ca-certificates
+        apt-get -y build-dep .
+    - name: Build
+      run: cargo build --verbose


### PR DESCRIPTION
This ensures that we're compatible with Debian's packaged version of rustc. Ideally we would run the full CI workflow (package build and installation) on Debian 10, but since that's best done on a full system and not a container to test systemd packaging etc., leave it alone for now.