### PR TITLE
Implement host lookups 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +334,7 @@ dependencies = [
  "atoi",
  "criterion",
  "crossbeam-channel",
+ "dns-lookup",
  "nix",
  "num-derive",
  "num-traits",
@@ -593,6 +606,16 @@ dependencies = [
  "term",
  "thread_local",
  "time",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ num-derive = "^0.3"
 num-traits = "^0.2"
 sd-notify = "^0.4"
 static_assertions = "1.1.0"
+dns-lookup = "1.0.8"
 
 [dev-dependencies]
 criterion = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Geoffrey Thomas <geoffrey.thomas@twosigma.com>",
     "Leif Walsh <leif.walsh@twosigma.com>",
 ]
-edition = "2018"
+edition = "2021"
 description = "The name service non-caching daemon"
 readme = "README.md"
 repository = "https://github.com/twosigma/nsncd"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-use nix::libc;
+use anyhow::bail;
+use nix::libc::{self};
+use std::ffi::{CStr, CString};
+use std::ptr;
 
 #[allow(non_camel_case_types)]
 type size_t = ::std::os::raw::c_ulonglong;
@@ -39,4 +42,255 @@ pub fn disable_internal_nscd() {
     unsafe {
         __nss_disable_nscd(do_nothing);
     }
+}
+
+pub enum LibcIp {
+    V4([u8; 4]),
+    V6([u8; 16])
+}
+
+mod glibcffi {
+    use nix::libc;
+    extern "C" {
+        pub fn gethostbyname2_r (
+            name: *const libc::c_char,
+            af: libc::c_int,
+            result_buf: *mut libc::hostent,
+            buf: *mut libc::c_char,
+            buflen: libc::size_t,
+            result: *mut *mut libc::hostent,
+            h_errnop: *mut libc::c_int,
+        ) -> libc::c_int;
+
+        pub fn gethostbyaddr_r (
+            addr: *const libc::c_void,
+            len: libc::socklen_t,
+            af: libc::c_int,
+            ret: *mut libc::hostent,
+            buf: *mut libc::c_char,
+            buflen: libc::size_t,
+            result: *mut *mut libc::hostent,
+            h_errnop: *mut libc::c_int,
+        ) -> libc::c_int;
+    }
+}
+
+/// This structure is the Rust counterpart of the `libc::hostent` C
+/// function the Libc hostent struct.
+///
+/// It's mostly used to perform the gethostbyaddr and gethostbyname
+/// operations.
+///
+/// This struct can be serialized to the wire through the
+/// `serialize` function or retrieved from the C boundary using the
+/// TryFrom `libc:hostent` trait.
+#[derive(Clone, Debug)]
+pub struct Hostent {
+    pub name: String,
+    pub aliases: Vec<String>,
+    pub addr_type: i32,
+    pub addr_list: Vec<std::net::IpAddr>,
+    pub herrno: i32
+}
+
+fn from_libc_hostent(value: libc::hostent) -> Result<Hostent, anyhow::Error> {
+    // validate value.h_addtype, and bail out if it's unsupported
+    if value.h_addrtype != libc::AF_INET && value.h_addrtype != libc::AF_INET6 {
+        bail!("unsupported address type: {}", value.h_addrtype);
+        }
+
+    // ensure value.h_length matches what we know from this address family
+    if value.h_addrtype == libc::AF_INET && value.h_length != 4 {
+        bail!("unsupported h_length for AF_INET: {}", value.h_length);
+    }
+    if value.h_addrtype == libc::AF_INET6 && value.h_length != 16 {
+        bail!("unsupported h_length for AF_INET6: {}", value.h_length);
+    }
+
+    let name = unsafe { CStr::from_ptr(value.h_name).to_str().unwrap().to_string() };
+
+    Ok({
+        // construct the list of aliases. keep adding to value.h_aliases until we encounter a null pointer.
+        let mut aliases: Vec<String> = Vec::new();
+        let mut h_alias_ptr = value.h_aliases as *const *const libc::c_char;
+        while !(unsafe { *h_alias_ptr }).is_null() {
+            aliases.push(unsafe { CStr::from_ptr(*h_alias_ptr).to_str().unwrap().to_string() });
+            // increment
+            unsafe {
+                h_alias_ptr = h_alias_ptr.add(1);
+            }
+        }
+        // value.h_addrtype
+
+        // construct the list of addresses.
+        let mut addr_list: Vec<std::net::IpAddr> = Vec::new();
+
+        // copy the pointer into a private variable that we can mutate
+        // h_addr_list is a pointer to a list of pointers to addresses.
+        // h_addr_list[0] => ptr to first address
+        // h_addr_list[1] => null pointer (end of list)
+        let mut h_addr_ptr = value.h_addr_list as *const *const libc::c_void;
+        while !(unsafe { *h_addr_ptr }).is_null() {
+            if value.h_addrtype == libc::AF_INET {
+                let octets: [u8; 4] =
+                    unsafe { std::ptr::read((*h_addr_ptr) as *const [u8; 4]) };
+                addr_list.push(std::net::IpAddr::V4(std::net::Ipv4Addr::from(octets)));
+            } else {
+                let octets: [u8; 16] =
+                    unsafe { std::ptr::read((*h_addr_ptr) as *const [u8; 16]) };
+                addr_list.push(std::net::IpAddr::V6(std::net::Ipv6Addr::from(octets)));
+            }
+            unsafe { h_addr_ptr = h_addr_ptr.add(1) };
+        }
+
+        Hostent {
+            name,
+            aliases,
+            addr_type: value.h_addrtype,
+            addr_list,
+            herrno: 0
+        }
+    })
+}
+
+/// Decodes the result of a gethostbyname/addr call into a `Hostent`
+/// Rust struct.
+///
+/// This decoding algorithm is quite confusing, but that's how it's
+/// implemented in Nscd and what the client Glibc expects. We
+/// basically always ignore `herrno` except if the resulting
+/// `libc::hostent` is set to null by glibc.
+fn unmarshal_gethostbyxx(hostent: *mut libc::hostent, herrno: libc::c_int) -> anyhow::Result<Hostent> {
+    if !hostent.is_null() {
+        unsafe {
+            let res = from_libc_hostent(*hostent)?;
+            Ok(res)
+        }
+    } else {
+        Ok(
+            // This is a default hostent header we're supposed to use
+            // to convey a lookup error. This is a glibc quirk, I have
+            // nothing to do with that, don't blame me :)
+            Hostent {
+                name: "".to_string(),
+                aliases: Vec::new(),
+                addr_type: -1,
+                addr_list: Vec::new(),
+                herrno
+            }
+        )
+    }
+}
+
+pub fn gethostbyaddr_r(addr: LibcIp) -> anyhow::Result<Hostent> {
+
+    let (addr, len, af) = match addr {
+        LibcIp::V4(ref ipv4) => (ipv4 as &[u8], 4, libc::AF_INET),
+        LibcIp::V6(ref ipv6) => (ipv6 as &[u8], 16, libc::AF_INET6)
+    };
+
+    let mut ret_hostent: libc::hostent = libc::hostent {
+        h_name: ptr::null_mut(),
+        h_aliases: ptr::null_mut(),
+        h_addrtype: 0,
+        h_length: 0,
+        h_addr_list: ptr::null_mut(),
+    };
+    let mut herrno: libc::c_int = 0;
+    let mut hostent_result  = ptr::null_mut();
+    let mut buf: Vec<u8> = Vec::with_capacity(200);
+    loop {
+        let ret = unsafe {
+            glibcffi::gethostbyaddr_r(
+                addr.as_ptr() as *const libc::c_void,
+                len,
+                af,
+                &mut ret_hostent,
+                buf.as_mut_ptr() as *mut libc::c_char,
+                (buf.capacity() as size_t).try_into().unwrap(),
+                &mut hostent_result,
+                &mut herrno
+            )
+        };
+
+        if ret == libc::ERANGE {
+            buf.reserve(buf.capacity() * 2);
+        } else {
+            break;
+        }
+    };
+    unmarshal_gethostbyxx(hostent_result, herrno)
+}
+
+///
+///
+/// The stream is positioned at the first entry in the directory.
+///
+/// af is nix::libc::AF_INET6 or nix::libc::AF_INET6
+pub fn gethostbyname2_r(name: String, af: libc::c_int) -> anyhow::Result<Hostent> {
+    let name = CString::new(name).unwrap();
+
+    // Prepare a libc::hostent and the pointer to the result list,
+    // which will passed to the ffi::gethostbyname2_r call.
+    let mut ret_hostent: libc::hostent = libc::hostent {
+        h_name: ptr::null_mut(), // <- points to buf
+        h_aliases: ptr::null_mut(),
+        h_addrtype: 0,
+        h_length: 0,
+        h_addr_list: ptr::null_mut(),
+    };
+    let mut herrno: libc::c_int = 0;
+    let mut buf: Vec<u8> = Vec::with_capacity(200);
+    // We absolutely need to point hostent_result to the start of the
+    // result buffer. Glibc segfaults if we don't.
+    let mut hostent_result  = ptr::null_mut();
+    let _: i32 = loop {
+        let ret = unsafe {
+            glibcffi::gethostbyname2_r(
+                name.as_ptr(),
+                af,
+                &mut ret_hostent,
+                buf.as_mut_ptr() as *mut libc::c_char,
+                (buf.capacity() as size_t).try_into().unwrap(),
+                &mut hostent_result,
+                &mut herrno,
+            )
+        };
+        if ret == libc::ERANGE {
+            // The buffer is too small. Let's x2 its capacity and retry.
+            buf.reserve(buf.capacity() * 2);
+        } else {
+            break ret;
+        }
+    };
+    unmarshal_gethostbyxx(hostent_result, herrno)
+}
+
+#[test]
+fn test_gethostbyname2_r() {
+    disable_internal_nscd();
+
+    let result: Result<Hostent, anyhow::Error> = gethostbyname2_r(
+        "localhost.".to_string(),
+        libc::AF_INET,
+    );
+
+    result.expect("Should resolve IPv4 localhost.");
+
+    let result: Result<Hostent, anyhow::Error> = gethostbyname2_r(
+        "localhost.".to_string(),
+        libc::AF_INET6,
+    );
+    result.expect("Should resolve IPv6 localhost.");
+}
+
+#[test]
+fn test_gethostbyaddr_r() {
+    disable_internal_nscd();
+
+    let v4test = LibcIp::V4([127,0,0,1]);
+    let _ = gethostbyaddr_r(v4test).expect("Should resolve IPv4 localhost with gethostbyaddr");
+
+    let v6test = LibcIp::V6([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1]);
+    let _ = gethostbyaddr_r(v6test).expect("Should resolve IPv6 localhost with gethostbyaddr");
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -222,20 +222,19 @@ pub fn handle_request(
                 ..AddrInfoHints::default()
             };
 
-            let host = match getaddrinfo(Some(hostname), None, Some(hints)) {
-                Ok(addrs) => {
-                    let addresses: std::io::Result<Vec<_>> = addrs
-                        .filter(|x| match x {
-                            Err(_) => false,
-                            Ok(addr) => addr.sockaddr.is_ipv4(),
-                        })
-                        .map(|r| r.map(|a| a.sockaddr.ip()))
-                        .collect();
-                    Ok(Some(Host {
-                        addresses: addresses?,
-                        hostname: hostname.to_string(),
-                    }))
-                }
+            let host = match getaddrinfo(Some(hostname), None, Some(hints)).map(|addrs| {
+                addrs
+                    .filter_map(|r| r.ok())
+                    .filter(|r| r.sockaddr.is_ipv4())
+                    .map(|a| a.sockaddr.ip())
+                    .collect::<Vec<_>>()
+            }) {
+                // no matches found
+                Ok(addresses) if addresses.len() == 0 => Ok(None),
+                Ok(addresses) => Ok(Some(Host {
+                    addresses,
+                    hostname: hostname.to_string(),
+                })),
                 Err(e) => match e.kind() {
                     dns_lookup::LookupErrorKind::NoName => Ok(None),
                     _ => bail!("error during lookup: {:?}", e),

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -252,20 +252,19 @@ pub fn handle_request(
                 ..AddrInfoHints::default()
             };
 
-            let host = match getaddrinfo(Some(hostname), None, Some(hints)) {
-                Ok(addrs) => {
-                    let addresses: std::io::Result<Vec<_>> = addrs
-                        .filter(|x| match x {
-                            Err(_) => false,
-                            Ok(addr) => addr.sockaddr.is_ipv6(),
-                        })
-                        .map(|r| r.map(|a| a.sockaddr.ip()))
-                        .collect();
-                    Ok(Some(Host {
-                        addresses: addresses?,
-                        hostname: hostname.to_string(),
-                    }))
-                }
+            let host = match getaddrinfo(Some(hostname), None, Some(hints)).map(|addrs| {
+                addrs
+                    .filter_map(|r| r.ok())
+                    .filter(|r| r.sockaddr.is_ipv6())
+                    .map(|a| a.sockaddr.ip())
+                    .collect::<Vec<_>>()
+            }) {
+                // No matches found
+                Ok(addresses) if addresses.len() == 0 => Ok(None),
+                Ok(addresses) => Ok(Some(Host {
+                    addresses,
+                    hostname: hostname.to_string(),
+                })),
                 Err(e) => match e.kind() {
                     dns_lookup::LookupErrorKind::NoName => Ok(None),
                     _ => bail!("error during lookup: {:?}", e),

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -21,8 +21,8 @@ use std::os::unix::ffi::OsStrExt;
 
 use anyhow::{bail, Context, Result};
 use atoi::atoi;
-use dns_lookup::getnameinfo;
-use nix::libc::NI_NUMERICSERV;
+use dns_lookup::{getaddrinfo, getnameinfo, AddrInfoHints};
+use nix::libc::{AF_INET6, NI_NUMERICSERV, SOCK_STREAM};
 use nix::unistd::{getgrouplist, Gid, Group, Uid, User};
 use slog::{debug, error, Logger};
 
@@ -184,6 +184,66 @@ pub fn handle_request(
             Ok(serialize_host(log, host))
         }
 
+        RequestType::GETHOSTBYNAME => {
+            let hostname = CStr::from_bytes_with_nul(request.key)?.to_str()?;
+            let hints = AddrInfoHints {
+                socktype: SOCK_STREAM,
+                ..AddrInfoHints::default()
+            };
+
+            let host = match getaddrinfo(Some(hostname), None, Some(hints)) {
+                Ok(addrs) => {
+                    let addresses: std::io::Result<Vec<_>> = addrs
+                        .filter(|x| match x {
+                            Err(_) => false,
+                            Ok(addr) => addr.sockaddr.is_ipv4(),
+                        })
+                        .map(|r| r.map(|a| a.sockaddr.ip()))
+                        .collect();
+                    Ok(Some(Host {
+                        addresses: addresses?,
+                        hostname: hostname.to_string(),
+                    }))
+                }
+                Err(e) => match e.kind() {
+                    dns_lookup::LookupErrorKind::NoName => Ok(None),
+                    _ => bail!("error during lookup: {:?}", e),
+                },
+            };
+            Ok(serialize_host(log, host))
+        }
+
+        RequestType::GETHOSTBYNAMEv6 => {
+            let hostname = CStr::from_bytes_with_nul(request.key)?.to_str()?;
+
+            let hints = AddrInfoHints {
+                socktype: SOCK_STREAM,
+                address: AF_INET6, // ai_family
+                ..AddrInfoHints::default()
+            };
+
+            let host = match getaddrinfo(Some(hostname), None, Some(hints)) {
+                Ok(addrs) => {
+                    let addresses: std::io::Result<Vec<_>> = addrs
+                        .filter(|x| match x {
+                            Err(_) => false,
+                            Ok(addr) => addr.sockaddr.is_ipv6(),
+                        })
+                        .map(|r| r.map(|a| a.sockaddr.ip()))
+                        .collect();
+                    Ok(Some(Host {
+                        addresses: addresses?,
+                        hostname: hostname.to_string(),
+                    }))
+                }
+                Err(e) => match e.kind() {
+                    dns_lookup::LookupErrorKind::NoName => Ok(None),
+                    _ => bail!("error during lookup: {:?}", e),
+                },
+            };
+            Ok(serialize_host(log, host))
+        }
+
         // These will normally send an FD pointing to the internal cache structure,
         // which clients use to look into the cache contents on their own.
         // We don't cache, and we don't want clients to poke around in cache structures either.
@@ -198,9 +258,7 @@ pub fn handle_request(
         }
 
         // Not implemented (yet)
-        RequestType::GETHOSTBYNAME
-        | RequestType::GETHOSTBYNAMEv6
-        | RequestType::GETSTAT
+        RequestType::GETSTAT
         | RequestType::GETAI
         | RequestType::GETSERVBYNAME
         | RequestType::GETSERVBYPORT

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -560,9 +560,7 @@ fn serialize_host(log: &slog::Logger, host: Result<Option<Host>>) -> Vec<u8> {
                 error: protocol::H_ERRNO_HOST_NOT_FOUND as i32,
             };
 
-            let mut buf = Vec::with_capacity(4 * 8);
-            buf.extend_from_slice(header.as_slice());
-            Ok(buf)
+            Ok(header.as_slice().to_vec())
         }
         Err(e) => {
             // pass along error
@@ -585,9 +583,7 @@ fn serialize_host(log: &slog::Logger, host: Result<Option<Host>>) -> Vec<u8> {
                 error: 0,
             };
 
-            let mut buf = Vec::with_capacity(4 * 8);
-            buf.extend_from_slice(header.as_slice());
-            buf
+            header.as_slice().to_vec()
         }
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -568,17 +568,7 @@ fn serialize_host(log: &slog::Logger, host: Result<Option<Host>>) -> Vec<u8> {
     let result = match host {
         Ok(Some(host)) => host.serialize(),
         Ok(None) => {
-            let header = protocol::HstResponseHeader {
-                version: protocol::VERSION,
-                found: 0,
-                h_name_len: 0,
-                h_aliases_cnt: 0,
-                h_addrtype: -1 as i32,
-                h_length: -1 as i32,
-                h_addr_list_cnt: 0,
-                error: protocol::H_ERRNO_HOST_NOT_FOUND as i32,
-            };
-
+            let header = protocol::HstResponseHeader::ERRNO_HOST_NOT_FOUND;
             Ok(header.as_slice().to_vec())
         }
         Err(e) => {
@@ -591,17 +581,7 @@ fn serialize_host(log: &slog::Logger, host: Result<Option<Host>>) -> Vec<u8> {
         Ok(res) => res,
         Err(e) => {
             error!(log, "parsing request"; "err" => %e);
-            let header = protocol::HstResponseHeader {
-                version: protocol::VERSION,
-                found: 0,
-                h_name_len: 0,
-                h_aliases_cnt: 0,
-                h_addrtype: -1 as i32,
-                h_length: -1 as i32,
-                h_addr_list_cnt: protocol::H_ERRNO_NETDB_INTERNAL as i32,
-                error: 0,
-            };
-
+            let header = protocol::HstResponseHeader::ERRNO_NETDB_INTERNAL;
             header.as_slice().to_vec()
         }
     }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -16,11 +16,13 @@
 
 use std::convert::TryInto;
 use std::ffi::{CStr, CString};
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::os::unix::ffi::OsStrExt;
 
 use anyhow::{bail, Context, Result};
 use atoi::atoi;
+use dns_lookup::getnameinfo;
+use nix::libc::NI_NUMERICSERV;
 use nix::unistd::{getgrouplist, Gid, Group, Uid, User};
 use slog::{debug, error, Logger};
 
@@ -135,6 +137,53 @@ pub fn handle_request(
             Ok(vec![])
         }
 
+        // GETHOSTBYADDR and GETHOSTBYADDRv6 implement reverse lookup
+        // The key contains the address to look for.
+        RequestType::GETHOSTBYADDR => {
+            let key = request.key;
+
+            if key.len() != 4 {
+                bail!("Invalid key len: {}, expected 4", key.len());
+            }
+            let address_bytes: [u8; 4] = key.try_into()?;
+            let address = IpAddr::from(address_bytes);
+
+            let sock = SocketAddr::new(address, 0);
+            let host = match getnameinfo(&sock, NI_NUMERICSERV) {
+                Ok((hostname, _service)) => Ok(Some(Host {
+                    addresses: vec![address],
+                    hostname,
+                })),
+                Err(e) => match e.kind() {
+                    dns_lookup::LookupErrorKind::NoName => Ok(None),
+                    _ => bail!("error during lookup: {:?}", e),
+                },
+            };
+            Ok(serialize_host(log, host))
+        }
+        RequestType::GETHOSTBYADDRv6 => {
+            let key = request.key;
+
+            if key.len() != 16 {
+                bail!("Invalid key len: {}, expected 16", key.len());
+            }
+            let address_bytes: [u8; 16] = key.try_into()?;
+            let address = IpAddr::from(address_bytes);
+
+            let sock = SocketAddr::new(address, 0);
+            let host = match getnameinfo(&sock, NI_NUMERICSERV) {
+                Ok((hostname, _service)) => Ok(Some(Host {
+                    addresses: vec![address],
+                    hostname,
+                })),
+                Err(e) => match e.kind() {
+                    dns_lookup::LookupErrorKind::NoName => Ok(None),
+                    _ => bail!("error during lookup: {:?}", e),
+                },
+            };
+            Ok(serialize_host(log, host))
+        }
+
         // These will normally send an FD pointing to the internal cache structure,
         // which clients use to look into the cache contents on their own.
         // We don't cache, and we don't want clients to poke around in cache structures either.
@@ -149,9 +198,7 @@ pub fn handle_request(
         }
 
         // Not implemented (yet)
-        RequestType::GETHOSTBYADDR
-        | RequestType::GETHOSTBYADDRv6
-        | RequestType::GETHOSTBYNAME
+        RequestType::GETHOSTBYNAME
         | RequestType::GETHOSTBYNAMEv6
         | RequestType::GETSTAT
         | RequestType::GETAI
@@ -389,6 +436,8 @@ fn serialize_host(log: &slog::Logger, host: Result<Option<Host>>) -> Vec<u8> {
 #[cfg(test)]
 mod test {
     use super::super::config::Config;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
     use super::*;
 
     fn test_logger() -> slog::Logger {
@@ -433,5 +482,71 @@ mod test {
         let output = handle_request(&test_logger(), &Config::default(), &request)
             .expect("should handle request with no error");
         assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn test_handle_gethostbyaddr() {
+        let request = protocol::Request {
+            ty: protocol::RequestType::GETHOSTBYADDR,
+            key: &[127, 0, 0, 1],
+        };
+
+        let expected = serialize_host(
+            &test_logger(),
+            Ok(Some(Host {
+                addresses: vec![IpAddr::from(Ipv4Addr::new(127, 0, 0, 1))],
+                hostname: "localhost".to_string(),
+            })),
+        );
+
+        let output =
+            handle_request(&test_logger(), &Config::default(),  &request).expect("should handle request with no error");
+
+        assert_eq!(expected, output)
+    }
+
+    #[test]
+    fn test_handle_gethostbyaddr_invalid_len() {
+        let request = protocol::Request {
+            ty: protocol::RequestType::GETHOSTBYADDR,
+            key: &[127, 0, 0],
+        };
+
+        let result = handle_request(&test_logger(), &Config::default(), &request);
+
+        assert!(result.is_err(), "should error on invalid length");
+    }
+
+    #[test]
+    fn test_handle_gethostbyaddrv6() {
+        let request = protocol::Request {
+            ty: protocol::RequestType::GETHOSTBYADDRv6,
+            key: &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+        };
+
+        let expected = serialize_host(
+            &test_logger(),
+            Ok(Some(Host {
+                addresses: vec![IpAddr::from(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
+                hostname: "localhost".to_string(),
+            })),
+        );
+
+        let output =
+            handle_request(&test_logger(), &Config::default(), &request).expect("should handle request with no error");
+
+        assert_eq!(expected, output)
+    }
+
+    #[test]
+    fn test_handle_gethostbyaddrv6_invalid_len() {
+        let request = protocol::Request {
+            ty: protocol::RequestType::GETHOSTBYADDRv6,
+            key: &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        };
+
+        let result = handle_request(&test_logger(), &Config::default(), &request);
+
+        assert!(result.is_err(), "should error on invalid length");
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -478,7 +478,7 @@ fn serialize_address_info(resp: &AiResponse) -> Result<Vec<u8>> {
 /// Send a gethostby{addr,name}{,v6} entry back to the client,
 /// or a response indicating the lookup failed.
 fn serialize_host(log: &slog::Logger, host: Result<Option<Host>>) -> Vec<u8> {
-    let result = || {
+    let result = {
         match host {
             Ok(Some(host)) => {
                 // Loop over all addresses.
@@ -570,7 +570,7 @@ fn serialize_host(log: &slog::Logger, host: Result<Option<Host>>) -> Vec<u8> {
         }
     };
 
-    match result() {
+    match result {
         Ok(res) => res,
         Err(e) => {
             error!(log, "parsing request"; "err" => %e);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -16,9 +16,10 @@
 
 use std::convert::TryInto;
 use std::ffi::{CStr, CString};
+use std::net::IpAddr;
 use std::os::unix::ffi::OsStrExt;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use atoi::atoi;
 use nix::unistd::{getgrouplist, Gid, Group, Uid, User};
 use slog::{debug, error, Logger};
@@ -260,6 +261,129 @@ fn serialize_initgroups(groups: Vec<Gid>) -> Result<Vec<u8>> {
     }
 
     Ok(result)
+}
+
+pub struct Host {
+    pub addresses: Vec<std::net::IpAddr>,
+    // aliases is unused so far
+    pub hostname: String,
+}
+
+/// Send a gethostby{addr,name}{,v6} entry back to the client,
+/// or a response indicating the lookup failed.
+fn serialize_host(log: &slog::Logger, host: Result<Option<Host>>) -> Vec<u8> {
+    let result = || {
+        match host {
+            Ok(Some(host)) => {
+                // Loop over all addresses.
+                // Serialize them into a slice, which is used later in the payload.
+                // Take note of the number of addresses (by AF).
+                let mut num_v4 = 0;
+                let mut num_v6 = 0;
+                let mut buf_addrs = vec![];
+
+                for address in host.addresses {
+                    match address {
+                        IpAddr::V4(ip4) => {
+                            num_v4 += 1;
+                            for octet in ip4.octets() {
+                                buf_addrs.push(octet)
+                            }
+                        }
+                        IpAddr::V6(ip6) => {
+                            num_v6 += 1;
+                            for octet in ip6.octets() {
+                                buf_addrs.push(octet)
+                            }
+                        }
+                    }
+                }
+
+                // this can only ever express one address family
+                if num_v4 != 0 && num_v6 != 0 {
+                    bail!("unable to serialize mixed AF")
+                }
+
+                let num_addrs = num_v4 + num_v6;
+
+                let hostname_c_string_bytes =
+                    CString::new(host.hostname.clone())?.into_bytes_with_nul();
+                let hostname_c_string_len = hostname_c_string_bytes.len();
+
+                let header = protocol::HstResponseHeader {
+                    version: protocol::VERSION,
+                    found: 1 as i32,
+                    h_name_len: hostname_c_string_len as i32,
+                    h_aliases_cnt: 0 as i32,
+                    h_addrtype: if num_v4 != 0 {
+                        nix::sys::socket::AddressFamily::Inet as i32
+                    } else {
+                        nix::sys::socket::AddressFamily::Inet6 as i32
+                    },
+                    h_length: if num_v4 != 0 { 4 as i32 } else { 16 as i32 },
+                    h_addr_list_cnt: num_addrs as i32,
+                    error: 0,
+                };
+
+                let total_len = 4 * 8 + hostname_c_string_len as i32 + buf_addrs.len() as i32;
+                let mut buf = Vec::with_capacity(total_len as usize);
+
+                // add header
+                buf.extend_from_slice(header.as_slice());
+
+                // add hostname
+                buf.extend_from_slice(&hostname_c_string_bytes);
+
+                // add serialized addresses from buf_addrs
+                buf.extend_from_slice(buf_addrs.as_slice());
+
+                debug_assert_eq!(buf.len() as i32, total_len);
+
+                Ok(buf)
+            }
+            Ok(None) => {
+                let header = protocol::HstResponseHeader {
+                    version: protocol::VERSION,
+                    found: 0,
+                    h_name_len: 0,
+                    h_aliases_cnt: 0,
+                    h_addrtype: -1 as i32,
+                    h_length: -1 as i32,
+                    h_addr_list_cnt: 0,
+                    error: protocol::H_ERRNO_HOST_NOT_FOUND as i32,
+                };
+
+                let mut buf = Vec::with_capacity(4 * 8);
+                buf.extend_from_slice(header.as_slice());
+                Ok(buf)
+            }
+            Err(e) => {
+                // pass along error
+                Err(e)
+            }
+        }
+    };
+
+    match result() {
+        Ok(res) => res,
+        Err(e) => {
+            error!(log, "parsing request"; "err" => %e);
+            let header = protocol::HstResponseHeader {
+                version: protocol::VERSION,
+                found: 0,
+                h_name_len: 0,
+                h_aliases_cnt: 0,
+                h_addrtype: -1 as i32,
+                h_length: -1 as i32,
+                h_addr_list_cnt: protocol::H_ERRNO_NETDB_INTERNAL as i32,
+                error: 0,
+            };
+
+            let mut buf = Vec::with_capacity(4 * 8);
+            buf.extend_from_slice(header.as_slice());
+            buf
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -403,6 +403,75 @@ pub struct Host {
     pub hostname: String,
 }
 
+impl Host {
+    fn serialize(&self) -> Result<Vec<u8>> {
+        // Loop over all addresses.
+        // Serialize them into a slice, which is used later in the payload.
+        // Take note of the number of addresses (by AF).
+        let mut num_v4 = 0;
+        let mut num_v6 = 0;
+        let mut buf_addrs = vec![];
+
+        for address in self.addresses.iter() {
+            match address {
+                IpAddr::V4(ip4) => {
+                    num_v4 += 1;
+                    for octet in ip4.octets() {
+                        buf_addrs.push(octet)
+                    }
+                }
+                IpAddr::V6(ip6) => {
+                    num_v6 += 1;
+                    for octet in ip6.octets() {
+                        buf_addrs.push(octet)
+                    }
+                }
+            }
+        }
+
+        // this can only ever express one address family
+        if num_v4 != 0 && num_v6 != 0 {
+            bail!("unable to serialize mixed AF")
+        }
+
+        let num_addrs = num_v4 + num_v6;
+
+        let hostname_c_string_bytes = CString::new(self.hostname.clone())?.into_bytes_with_nul();
+        let hostname_c_string_len = hostname_c_string_bytes.len();
+
+        let header = protocol::HstResponseHeader {
+            version: protocol::VERSION,
+            found: 1 as i32,
+            h_name_len: hostname_c_string_len as i32,
+            h_aliases_cnt: 0 as i32,
+            h_addrtype: if num_v4 != 0 {
+                nix::sys::socket::AddressFamily::Inet as i32
+            } else {
+                nix::sys::socket::AddressFamily::Inet6 as i32
+            },
+            h_length: if num_v4 != 0 { 4 as i32 } else { 16 as i32 },
+            h_addr_list_cnt: num_addrs as i32,
+            error: 0,
+        };
+
+        let total_len = 4 * 8 + hostname_c_string_len as i32 + buf_addrs.len() as i32;
+        let mut buf = Vec::with_capacity(total_len as usize);
+
+        // add header
+        buf.extend_from_slice(header.as_slice());
+
+        // add hostname
+        buf.extend_from_slice(&hostname_c_string_bytes);
+
+        // add serialized addresses from buf_addrs
+        buf.extend_from_slice(buf_addrs.as_slice());
+
+        debug_assert_eq!(buf.len() as i32, total_len);
+
+	Ok(buf)
+    }
+}
+
 /// Serialize a [RequestType::GETAI] response to the wire.
 ///
 /// This wire format has been implemented by reading the `addhstaiX`
@@ -478,95 +547,27 @@ fn serialize_address_info(resp: &AiResponse) -> Result<Vec<u8>> {
 /// Send a gethostby{addr,name}{,v6} entry back to the client,
 /// or a response indicating the lookup failed.
 fn serialize_host(log: &slog::Logger, host: Result<Option<Host>>) -> Vec<u8> {
-    let result = {
-        match host {
-            Ok(Some(host)) => {
-                // Loop over all addresses.
-                // Serialize them into a slice, which is used later in the payload.
-                // Take note of the number of addresses (by AF).
-                let mut num_v4 = 0;
-                let mut num_v6 = 0;
-                let mut buf_addrs = vec![];
+    let result = match host {
+        Ok(Some(host)) => host.serialize(),
+        Ok(None) => {
+            let header = protocol::HstResponseHeader {
+                version: protocol::VERSION,
+                found: 0,
+                h_name_len: 0,
+                h_aliases_cnt: 0,
+                h_addrtype: -1 as i32,
+                h_length: -1 as i32,
+                h_addr_list_cnt: 0,
+                error: protocol::H_ERRNO_HOST_NOT_FOUND as i32,
+            };
 
-                for address in host.addresses {
-                    match address {
-                        IpAddr::V4(ip4) => {
-                            num_v4 += 1;
-                            for octet in ip4.octets() {
-                                buf_addrs.push(octet)
-                            }
-                        }
-                        IpAddr::V6(ip6) => {
-                            num_v6 += 1;
-                            for octet in ip6.octets() {
-                                buf_addrs.push(octet)
-                            }
-                        }
-                    }
-                }
-
-                // this can only ever express one address family
-                if num_v4 != 0 && num_v6 != 0 {
-                    bail!("unable to serialize mixed AF")
-                }
-
-                let num_addrs = num_v4 + num_v6;
-
-                let hostname_c_string_bytes =
-                    CString::new(host.hostname.clone())?.into_bytes_with_nul();
-                let hostname_c_string_len = hostname_c_string_bytes.len();
-
-                let header = protocol::HstResponseHeader {
-                    version: protocol::VERSION,
-                    found: 1 as i32,
-                    h_name_len: hostname_c_string_len as i32,
-                    h_aliases_cnt: 0 as i32,
-                    h_addrtype: if num_v4 != 0 {
-                        nix::sys::socket::AddressFamily::Inet as i32
-                    } else {
-                        nix::sys::socket::AddressFamily::Inet6 as i32
-                    },
-                    h_length: if num_v4 != 0 { 4 as i32 } else { 16 as i32 },
-                    h_addr_list_cnt: num_addrs as i32,
-                    error: 0,
-                };
-
-                let total_len = 4 * 8 + hostname_c_string_len as i32 + buf_addrs.len() as i32;
-                let mut buf = Vec::with_capacity(total_len as usize);
-
-                // add header
-                buf.extend_from_slice(header.as_slice());
-
-                // add hostname
-                buf.extend_from_slice(&hostname_c_string_bytes);
-
-                // add serialized addresses from buf_addrs
-                buf.extend_from_slice(buf_addrs.as_slice());
-
-                debug_assert_eq!(buf.len() as i32, total_len);
-
-                Ok(buf)
-            }
-            Ok(None) => {
-                let header = protocol::HstResponseHeader {
-                    version: protocol::VERSION,
-                    found: 0,
-                    h_name_len: 0,
-                    h_aliases_cnt: 0,
-                    h_addrtype: -1 as i32,
-                    h_length: -1 as i32,
-                    h_addr_list_cnt: 0,
-                    error: protocol::H_ERRNO_HOST_NOT_FOUND as i32,
-                };
-
-                let mut buf = Vec::with_capacity(4 * 8);
-                buf.extend_from_slice(header.as_slice());
-                Ok(buf)
-            }
-            Err(e) => {
-                // pass along error
-                Err(e)
-            }
+            let mut buf = Vec::with_capacity(4 * 8);
+            buf.extend_from_slice(header.as_slice());
+            Ok(buf)
+        }
+        Err(e) => {
+            // pass along error
+            Err(e)
         }
     };
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -264,6 +264,33 @@ impl HstResponseHeader {
         let p = self as *const _ as *const u8;
         unsafe { std::slice::from_raw_parts(p, size_of::<Self>()) }
     }
+
+    /// Return the serialized header as vector of bytes
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.as_slice().to_vec()
+    }
+
+    pub const ERRNO_HOST_NOT_FOUND: Self = Self {
+        version: VERSION,
+        found: 0,
+        h_name_len: 0,
+        h_aliases_cnt: 0,
+        h_addrtype: -1 as i32,
+        h_length: -1 as i32,
+        h_addr_list_cnt: 0,
+        error: H_ERRNO_HOST_NOT_FOUND as i32,
+    };
+
+    pub const ERRNO_NETDB_INTERNAL: Self = Self {
+        version: VERSION,
+        found: 0,
+        h_name_len: 0,
+        h_aliases_cnt: 0,
+        h_addrtype: -1 as i32,
+        h_length: -1 as i32,
+        h_addr_list_cnt: H_ERRNO_NETDB_INTERNAL as i32,
+        error: 0,
+    };
 }
 
 #[cfg(test)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -35,6 +35,12 @@ use nix::libc::{c_int, gid_t, uid_t};
 /// of each message header.
 pub const VERSION: i32 = 2;
 
+/// Errors used in HstResponseHeader struct
+pub const H_ERRNO_NETDB_INTERNAL: i32 = -1;
+pub const H_ERRNO_HOST_NOT_FOUND: i32 = 1; // Authoritative Answer Host not found.
+#[allow(dead_code)]
+pub const H_ERRNO_TRY_AGAIN: i32 = 2; // Non-Authoritative Host not found
+
 /// Available services. This enum describes all service types the nscd protocol
 /// knows about, though we only implement `GETPW*`, `GETGR*`, and `INITGROUPS`.
 #[derive(Clone, Copy, Debug, FromPrimitive, ToPrimitive)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -38,8 +38,6 @@ pub const VERSION: i32 = 2;
 /// Errors used in {Ai,Hst}ResponseHeader structs.
 /// See NSCD's resolv/netdb.h for the complete list.
 pub const H_ERRNO_NETDB_SUCCESS: i32 = 0;
-pub const H_ERRNO_NETDB_INTERNAL: i32 = -1;
-pub const H_ERRNO_HOST_NOT_FOUND: i32 = 1; // Authoritative Answer Host not found.
 #[allow(dead_code)]
 pub const H_ERRNO_TRY_AGAIN: i32 = 2; // Non-Authoritative Host not found
 
@@ -264,33 +262,6 @@ impl HstResponseHeader {
         let p = self as *const _ as *const u8;
         unsafe { std::slice::from_raw_parts(p, size_of::<Self>()) }
     }
-
-    /// Return the serialized header as vector of bytes
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.as_slice().to_vec()
-    }
-
-    pub const ERRNO_HOST_NOT_FOUND: Self = Self {
-        version: VERSION,
-        found: 0,
-        h_name_len: 0,
-        h_aliases_cnt: 0,
-        h_addrtype: -1 as i32,
-        h_length: -1 as i32,
-        h_addr_list_cnt: 0,
-        error: H_ERRNO_HOST_NOT_FOUND as i32,
-    };
-
-    pub const ERRNO_NETDB_INTERNAL: Self = Self {
-        version: VERSION,
-        found: 0,
-        h_name_len: 0,
-        h_aliases_cnt: 0,
-        h_addrtype: -1 as i32,
-        h_length: -1 as i32,
-        h_addr_list_cnt: H_ERRNO_NETDB_INTERNAL as i32,
-        error: 0,
-    };
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This adds support for the following request types:

 - GETAI
 - GETHOSTBYADDR
 - GETHOSTBYADDRv6
 - GETHOSTBYNAME
 - GETHOSTBYNAMEv6

Cherry-picked into one PR due to https://github.com/twosigma/nsncd/pull/39#issuecomment-1279858396:

> Note that they both have to be merged in the same release because glibc's NSCD client disables lookups for the whole hosts family of operations if one operation comes back unimplemented (see also https://github.com/twosigma/nsncd/pull/26, where it disabled lookups for the whole groups family of operations), but that shouldn't be hard to do. I don't see any other host operations I think.

Fixes #37.
Supersedes #39 and #40.