### PR TITLE
debian: Explicitly build deb with xz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nsncd"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
     "Ben Linsay <ben.linsay@twosigma.com>",
     "Geoffrey Thomas <geoffrey.thomas@twosigma.com>",

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nsncd (1.4.1) unstable; urgency=medium
+
+  * Explicitly build deb with xz, so Ubuntu builders produce a deb
+    compatible with Debian stable.
+
+ -- Geoffrey Thomas <geofft@twosigma.com>  Tue, 25 Apr 2023 15:12:56 -0400
+
 nsncd (1.4) unstable; urgency=low
 
   * Added environment-based runtime configuration (#51).

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,9 @@ override_dh_auto_build:
 override_dh_auto_clean:
 	cargo clean
 
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
+
 # See README.source.
 vendor:
 	mkdir -p .cargo


### PR DESCRIPTION
Otherwise Ubuntu defaults to zstd, which Debian stable doesn't support. (xz is supported as far back as Debian 6 "squeeze".)