### PR TITLE
Revert "debian: Explicitly build deb with xz"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "nsncd"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "atoi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nsncd"
-version = "1.4.1"
+version = "1.4.0"
 authors = [
     "Ben Linsay <ben.linsay@twosigma.com>",
     "Geoffrey Thomas <geoffrey.thomas@twosigma.com>",

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,3 @@
-nsncd (1.4.1) unstable; urgency=medium
-
-  * Explicitly build deb with xz, so Ubuntu builders produce a deb
-    compatible with Debian stable.
-
- -- Geoffrey Thomas <geofft@twosigma.com>  Tue, 25 Apr 2023 15:12:56 -0400
-
 nsncd (1.4) unstable; urgency=low
 
   * Added environment-based runtime configuration (#51).


### PR DESCRIPTION
replaces #62 since #61 erased part of the commit it was reverting