### PR TITLE
fix --out xml argument to tarpaulin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           toolchain: ${{ github.event.schedule && 'nightly' || 'stable' }}
       - name: Generate code coverage
-        run: cargo tarpaulin --all-features --workspace --timeout 120 --out Xml
+        run: cargo tarpaulin --all-features --workspace --timeout 120 --out xml
       - uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
Was broken by https://github.com/xd009642/tarpaulin/commit/d1bd48ea2ac1356ea3087b5d2d197ee58702dbd0 (and our nightly tests caught it)