### PR TITLE
implement host lookup support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5766087c2235fec47fafa4cfecc81e494ee679d0fd4a59887ea0919bfb0e4fc"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "linux-raw-sys"
@@ -405,6 +417,7 @@ dependencies = [
  "atoi",
  "criterion",
  "crossbeam-channel",
+ "dns-lookup",
  "nix",
  "num-derive",
  "num-traits",
@@ -683,6 +696,16 @@ dependencies = [
  "term",
  "thread_local",
  "time",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ num-derive = "^0.3"
 num-traits = "^0.2"
 sd-notify = "^0.4"
 static_assertions = "1.1.0"
+dns-lookup = "2.0.4"
 
 [dev-dependencies]
 criterion = "^0.5"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -171,6 +171,7 @@ fn from_libc_hostent(value: libc::hostent) -> anyhow::Result<Hostent> {
         aliases,
         addr_type: value.h_addrtype,
         addr_list,
+        // If we're here, glibc gave us an hostent. We should discard herrno to match the nscd behaviour.
         herrno: 0,
     })
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-use nix::libc;
+use anyhow::bail;
+use nix::libc::{self};
+use std::convert::TryInto;
+use std::ffi::{CStr, CString};
+use std::ptr;
 
 #[allow(non_camel_case_types)]
 type size_t = ::std::os::raw::c_ulonglong;
@@ -39,4 +43,249 @@ pub fn disable_internal_nscd() {
     unsafe {
         __nss_disable_nscd(do_nothing);
     }
+}
+
+pub enum LibcIp {
+    V4([u8; 4]),
+    V6([u8; 16]),
+}
+
+mod glibcffi {
+    use nix::libc;
+    extern "C" {
+        pub fn gethostbyname2_r(
+            name: *const libc::c_char,
+            af: libc::c_int,
+            result_buf: *mut libc::hostent,
+            buf: *mut libc::c_char,
+            buflen: libc::size_t,
+            result: *mut *mut libc::hostent,
+            h_errnop: *mut libc::c_int,
+        ) -> libc::c_int;
+
+        pub fn gethostbyaddr_r(
+            addr: *const libc::c_void,
+            len: libc::socklen_t,
+            af: libc::c_int,
+            ret: *mut libc::hostent,
+            buf: *mut libc::c_char,
+            buflen: libc::size_t,
+            result: *mut *mut libc::hostent,
+            h_errnop: *mut libc::c_int,
+        ) -> libc::c_int;
+    }
+}
+
+/// This structure is the Rust counterpart of the `libc::hostent` C
+/// function the Libc hostent struct.
+///
+/// It's mostly used to perform the gethostbyaddr and gethostbyname
+/// operations.
+///
+/// This struct can be serialized to the wire through the
+/// `serialize` function or retrieved from the C boundary using the
+/// TryFrom `libc:hostent` trait.
+#[derive(Clone, Debug)]
+pub struct Hostent {
+    pub name: String,
+    pub aliases: Vec<String>,
+    pub addr_type: i32,
+    pub addr_list: Vec<std::net::IpAddr>,
+    pub herrno: i32,
+}
+
+fn from_libc_hostent(value: libc::hostent) -> anyhow::Result<Hostent> {
+    // validate value.h_addtype, and bail out if it's unsupported
+    if value.h_addrtype != libc::AF_INET && value.h_addrtype != libc::AF_INET6 {
+        bail!("unsupported address type: {}", value.h_addrtype);
+    }
+
+    // ensure value.h_length matches what we know from this address family
+    if value.h_addrtype == libc::AF_INET && value.h_length != 4 {
+        bail!("unsupported h_length for AF_INET: {}", value.h_length);
+    }
+    if value.h_addrtype == libc::AF_INET6 && value.h_length != 16 {
+        bail!("unsupported h_length for AF_INET6: {}", value.h_length);
+    }
+
+    let name = unsafe { CStr::from_ptr(value.h_name).to_str().unwrap().to_string() };
+
+    Ok({
+        // construct the list of aliases. keep adding to value.h_aliases until we encounter a null pointer.
+        let mut aliases: Vec<String> = Vec::new();
+        let mut h_alias_ptr = value.h_aliases as *const *const libc::c_char;
+        while !(unsafe { *h_alias_ptr }).is_null() {
+            aliases.push(unsafe { CStr::from_ptr(*h_alias_ptr).to_str().unwrap().to_string() });
+            // increment
+            unsafe {
+                h_alias_ptr = h_alias_ptr.add(1);
+            }
+        }
+        // value.h_addrtype
+
+        // construct the list of addresses.
+        let mut addr_list: Vec<std::net::IpAddr> = Vec::new();
+
+        // copy the pointer into a private variable that we can mutate
+        // h_addr_list is a pointer to a list of pointers to addresses.
+        // h_addr_list[0] => ptr to first address
+        // h_addr_list[1] => null pointer (end of list)
+        let mut h_addr_ptr = value.h_addr_list as *const *const libc::c_void;
+        while !(unsafe { *h_addr_ptr }).is_null() {
+            if value.h_addrtype == libc::AF_INET {
+                let octets: [u8; 4] = unsafe { std::ptr::read((*h_addr_ptr) as *const [u8; 4]) };
+                addr_list.push(std::net::IpAddr::V4(std::net::Ipv4Addr::from(octets)));
+            } else {
+                let octets: [u8; 16] = unsafe { std::ptr::read((*h_addr_ptr) as *const [u8; 16]) };
+                addr_list.push(std::net::IpAddr::V6(std::net::Ipv6Addr::from(octets)));
+            }
+            unsafe { h_addr_ptr = h_addr_ptr.add(1) };
+        }
+
+        Hostent {
+            name,
+            aliases,
+            addr_type: value.h_addrtype,
+            addr_list,
+            herrno: 0,
+        }
+    })
+}
+
+/// Decodes the result of a gethostbyname/addr call into a `Hostent`
+/// Rust struct.
+///
+/// This decoding algorithm is quite confusing, but that's how it's
+/// implemented in Nscd and what the client Glibc expects. We
+/// basically always ignore `herrno` except if the resulting
+/// `libc::hostent` is set to null by glibc.
+fn unmarshal_gethostbyxx(
+    hostent: *mut libc::hostent,
+    herrno: libc::c_int,
+) -> anyhow::Result<Hostent> {
+    if !hostent.is_null() {
+        let res = from_libc_hostent(unsafe { *hostent } )?;
+        Ok(res)
+    } else {
+        Ok(
+            // This is a default hostent header we're supposed to use
+            // to convey a lookup error. This is a glibc quirk, I have
+            // nothing to do with that, don't blame me :)
+            Hostent {
+                name: "".to_string(),
+                aliases: Vec::new(),
+                addr_type: -1,
+                addr_list: Vec::new(),
+                herrno,
+            },
+        )
+    }
+}
+
+pub fn gethostbyaddr_r(addr: LibcIp) -> anyhow::Result<Hostent> {
+    let (addr, len, af) = match addr {
+        LibcIp::V4(ref ipv4) => (ipv4 as &[u8], 4, libc::AF_INET),
+        LibcIp::V6(ref ipv6) => (ipv6 as &[u8], 16, libc::AF_INET6),
+    };
+
+    let mut ret_hostent: libc::hostent = libc::hostent {
+        h_name: ptr::null_mut(),
+        h_aliases: ptr::null_mut(),
+        h_addrtype: 0,
+        h_length: 0,
+        h_addr_list: ptr::null_mut(),
+    };
+    let mut herrno: libc::c_int = 0;
+    let mut hostent_result = ptr::null_mut();
+    // We start with a 1024 bytes buffer, the nscd default. See
+    // scratch_buffer.h in the glibc codebase
+    let mut buf: Vec<u8> = Vec::with_capacity(1024);
+    loop {
+        let ret = unsafe {
+            glibcffi::gethostbyaddr_r(
+                addr.as_ptr() as *const libc::c_void,
+                len,
+                af,
+                &mut ret_hostent,
+                buf.as_mut_ptr() as *mut libc::c_char,
+                (buf.capacity() as size_t).try_into().unwrap(),
+                &mut hostent_result,
+                &mut herrno,
+            )
+        };
+
+        if ret == libc::ERANGE && buf.capacity() < 10 * 1000 * 1000  {
+            buf.reserve(buf.capacity() * 2);
+        } else {
+            break;
+        }
+    }
+    unmarshal_gethostbyxx(hostent_result, herrno)
+}
+
+/// Typesafe wrapper around the gethostbyname2_r glibc function
+///
+/// af is either nix::libc::AF_INET or nix::libc::AF_INET6
+pub fn gethostbyname2_r(name: String, af: libc::c_int) -> anyhow::Result<Hostent> {
+    let name = CString::new(name).unwrap();
+
+    // Prepare a libc::hostent and the pointer to the result list,
+    // which will be passed to the glibcffi::gethostbyname2_r call.
+    let mut ret_hostent: libc::hostent = libc::hostent {
+        h_name: ptr::null_mut(),
+        h_aliases: ptr::null_mut(),
+        h_addrtype: 0,
+        h_length: 0,
+        h_addr_list: ptr::null_mut(),
+    };
+    let mut herrno: libc::c_int = 0;
+    // The 1024 initial size comes from the Glibc default. It fit most
+    // of the requests in practice.
+    let mut buf: Vec<u8> = Vec::with_capacity(1024);
+    let mut hostent_result = ptr::null_mut();
+    loop {
+        let ret = unsafe {
+            glibcffi::gethostbyname2_r(
+                name.as_ptr(),
+                af,
+                &mut ret_hostent,
+                buf.as_mut_ptr() as *mut libc::c_char,
+                (buf.capacity() as size_t).try_into().unwrap(),
+                &mut hostent_result,
+                &mut herrno,
+            )
+        };
+        if ret == libc::ERANGE {
+            // The buffer is too small. Let's x2 its capacity and retry.
+            buf.reserve(buf.capacity() * 2);
+        } else {
+            break;
+        }
+    };
+    unmarshal_gethostbyxx(hostent_result, herrno)
+}
+
+#[test]
+fn test_gethostbyname2_r() {
+    disable_internal_nscd();
+
+    let result: Result<Hostent, anyhow::Error> =
+        gethostbyname2_r("localhost.".to_string(), libc::AF_INET);
+
+    result.expect("Should resolve IPv4 localhost.");
+
+    let result: Result<Hostent, anyhow::Error> =
+        gethostbyname2_r("localhost.".to_string(), libc::AF_INET6);
+    result.expect("Should resolve IPv6 localhost.");
+}
+
+#[test]
+fn test_gethostbyaddr_r() {
+    disable_internal_nscd();
+
+    let v4test = LibcIp::V4([127, 0, 0, 1]);
+    let _ = gethostbyaddr_r(v4test).expect("Should resolve IPv4 localhost with gethostbyaddr");
+
+    let v6test = LibcIp::V6([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+    let _ = gethostbyaddr_r(v6test).expect("Should resolve IPv6 localhost with gethostbyaddr");
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -83,7 +83,7 @@ mod glibcffi {
 /// operations.
 ///
 /// This struct can be serialized to the wire through the
-/// `serialize` function or retrieved from the C boundary using the
+/// `serialize_hostent` function or retrieved from the C boundary using the
 /// TryFrom `libc:hostent` trait.
 #[derive(Clone, Debug)]
 pub struct Hostent {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -187,7 +187,7 @@ pub fn handle_request(
                 Err(_) => ai_resp_empty,
             };
 
-            serialize_address_info(&ai_resp)
+            serialize_address_info(ai_resp)
         }
 
         // GETHOSTBYADDR and GETHOSTBYADDRv6 implement reverse lookup
@@ -529,7 +529,7 @@ fn serialize_hostent(hostent: Hostent) -> Result<Vec<u8>> {
 ///    the associated IP addr family number. AF_INET for an IPv4,
 ///    AF_INET6 for a v6.
 /// 9. canon_name: Canonical name of the host. Null-terminated string.
-fn serialize_address_info(resp: &AiResponse) -> Result<Vec<u8>> {
+fn serialize_address_info(resp: AiResponse) -> Result<Vec<u8>> {
     let mut b_families: Vec<u8> = Vec::with_capacity(2);
     let mut b_addrs: Vec<u8> = Vec::with_capacity(2);
     for addr in &resp.addrs {
@@ -552,8 +552,7 @@ fn serialize_address_info(resp: &AiResponse) -> Result<Vec<u8>> {
     }
     let addrslen = b_addrs.len();
     if addrslen > 0 {
-        let canon_name = resp.canon_name.clone();
-        let b_canon_name = CString::new(canon_name)?.into_bytes_with_nul();
+        let b_canon_name = CString::new(resp.canon_name)?.into_bytes_with_nul();
         let ai_response_header = AiResponseHeader {
             version: protocol::VERSION,
             found: 1,
@@ -655,11 +654,11 @@ mod test {
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
         ]);
         let ai_resp_3 = gen_ai_resp(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]);
-        let expected_1: Vec<u8> = serialize_address_info(&ai_resp_1)
+        let expected_1: Vec<u8> = serialize_address_info(ai_resp_1)
             .expect("serialize_address_info should serialize correctly");
-        let expected_2: Vec<u8> = serialize_address_info(&ai_resp_2)
+        let expected_2: Vec<u8> = serialize_address_info(ai_resp_2)
             .expect("serialize_address_info should serialize correctly");
-        let expected_3: Vec<u8> = serialize_address_info(&ai_resp_3)
+        let expected_3: Vec<u8> = serialize_address_info(ai_resp_3)
             .expect("serialize_address_info should serialize correctly");
 
         let output = handle_request(&test_logger(), &Config::default(), &request)


### PR DESCRIPTION
This adds support for the GETAI, GETHOSTBYADDR, GETHOSTBYADDRv6, GETHOSTBYNAME, GETHOSTBYNAMEv6 request types.

For the more complex GETAI lookup, we use the dns_lookup crate.

In previous iterations of this change, we also used the same underlying getaddrinfo call to respond to the  gethostbyname/gethostbyaddr operations.

Even though gethostbyname/gethostbyaddr officially are deprecated, there's a lot of tools still using it, and relying on them behaving differently.

So it's important to still implement it, with exactly the same behaviour, to prevent some tools from breaking (like `hostname --fqdn`, see https://github.com/nix-community/nsncd/issues/4).

We FFI the right Glibc gethostbyname_2r/gethostbyaddr_2r (now deprecated) functions and use it to back the GETHOSTBYNAME, GETHOSTBYNAME6, GETHOSTBYADDR, and GETHOSTBYADDR6 Nscd interfaces.

Took us three tries to get this right. This is actually the third full rewrite.

The Nscd behaviour for these two legacy functions is *really* confusing. We're supposed to ignore the herrno (herrno != errno!!) and set it to 0 if gethostbyaddr/name returns a non-null hostent. If we end up with a null hostent, we return the herrno together with a dummy hostent header.

I tried to keep things as safe as possible by extracting the glibc hostent to a proper rust structure. This structure mirrors the libc hostent in a Rust idiomatic way. We should probably try to upstream the FFI part of this commit to the Nix crate at some point.

Fixes https://github.com/nix-community/nsncd/issues/4