### PR TITLE
Added support for libc built without nscd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,6 @@ readme = "README.md"
 repository = "https://github.com/twosigma/nsncd"
 license = "Apache-2.0"
 
-[features]
-# This feature enables building nsncd on systems where the host libc does NOT
-# have nscd support built-in. This *will* cause infinite recursion on systems
-# with nscd support in the libc.
-glibc_no_nscd = []
-
 [dependencies]
 anyhow = "^1.0"
 atoi = "^2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,12 @@ readme = "README.md"
 repository = "https://github.com/twosigma/nsncd"
 license = "Apache-2.0"
 
+[features]
+# This feature enables building nsncd on systems where the host libc does NOT
+# have nscd support built-in. This *will* cause infinite recursion on systems
+# with nscd support in the libc.
+glibc_no_nscd = []
+
 [dependencies]
 anyhow = "^1.0"
 atoi = "^2.0"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -37,6 +37,7 @@ extern "C" {
 /// We _are_ nscd, so we need to do the lookups, and not recurse.
 /// Until 2.14, this function was taking no parameters.
 /// In 2.15, it takes a function pointer from hell.
+#[cfg(not(feature="glibc_no_nscd"))]
 unsafe extern "C" fn do_nothing(_dbidx: size_t, _finfo: *mut libc::c_void) {}
 
 /// Disable nscd inside our own glibc to prevent recursion.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -47,7 +47,7 @@ pub fn disable_internal_nscd() {
         let __nss_disable_nscd =
             mem::transmute::<*mut libc::c_void, extern "C" fn(hell: unsafe extern "C" fn(size_t, *mut libc::c_void))>(sym_ptr);
 
-        if sym_ptr != ptr::null_mut() {
+        if !sym_ptr.is_null() {
             __nss_disable_nscd(do_nothing);
         }
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -23,6 +23,7 @@ use std::ptr;
 #[allow(non_camel_case_types)]
 type size_t = ::std::os::raw::c_ulonglong;
 
+#[cfg(not(feature="glibc_no_nscd"))]
 extern "C" {
     /// This is the function signature of the glibc internal function to
     /// disable using nscd for this process.
@@ -39,11 +40,15 @@ extern "C" {
 unsafe extern "C" fn do_nothing(_dbidx: size_t, _finfo: *mut libc::c_void) {}
 
 /// Disable nscd inside our own glibc to prevent recursion.
+#[cfg(not(feature="glibc_no_nscd"))]
 pub fn disable_internal_nscd() {
     unsafe {
         __nss_disable_nscd(do_nothing);
     }
 }
+
+#[cfg(feature="glibc_no_nscd")]
+pub fn disable_internal_nscd() { }
 
 pub enum LibcIp {
     V4([u8; 4]),

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -43,7 +43,7 @@ unsafe extern "C" fn do_nothing(_dbidx: size_t, _finfo: *mut libc::c_void) {}
 pub fn disable_internal_nscd() {
     unsafe {
         let sym_name = CString::new("__nss_disable_nscd").unwrap();
-        let sym_ptr = dlsym(ptr::null_mut(), sym_name.as_ptr());
+        let sym_ptr = dlsym(RTLD_DEFAULT, sym_name.as_ptr());
         if !sym_ptr.is_null() {
             let __nss_disable_nscd = mem::transmute::<
                 *mut libc::c_void,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -49,8 +49,6 @@ pub fn disable_internal_nscd() {
 
         if sym_ptr != ptr::null_mut() {
             __nss_disable_nscd(do_nothing);
-        } else {
-            println!("No nscd support, hum dee dum...");
         }
     }
 }


### PR DESCRIPTION
For reasons talked about over here https://github.com/twosigma/nsncd/issues/70#issuecomment-1942790292, this PR adds a non-default build feature, `glibc_no_nscd`, which allows `nsncd` to build on systems where the host `glibc` lacks `nscd` support, for use with e.g. programs installed using the Nix package manager.