### PR TITLE
add support for socket activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "listenfd"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0500463acd96259d219abb05dc57e5a076ef04b2db9a2112846929b5f174c96"
+dependencies = [
+ "libc",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +426,7 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "dns-lookup",
+ "listenfd",
  "nix",
  "num-derive",
  "num-traits",
@@ -843,6 +855,12 @@ name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "uuid"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ num-traits = "^0.2"
 sd-notify = "^0.4"
 static_assertions = "1.1.0"
 dns-lookup = "2.0.4"
+listenfd = "1.0.1"
 
 [dev-dependencies]
 criterion = "^0.5"


### PR DESCRIPTION
If nsncd is started using socket activation, use the passed FD instead of manually binding on SOCKET_PATH.

This doesn't change any current behaviour in the currently documented startup mode, but makes nsncd fit to run in a socket-activated environment.