### PR TITLE
Issue 123 - enhance CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,9 +239,26 @@ jobs:
         env:
           HAVE_SYSTEMD: "0"
 
+  # This step deliberately uses a vm
+  run-enhanced-ci-debian-11:
+    runs-on: ubuntu-latest
+    needs: [build-debian-package-11]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install build-essential systemd-container debootstrap
+      - uses: actions/download-artifact@v3
+        with:
+          name: deb-package-debian-11
+      - name: CI
+        run: ci/test_nspawn.sh
+
   create-release:
     runs-on: ubuntu-latest
-    needs: [run-ci-ubuntu-latest, run-ci-debian-11, run-ci-debian-12, run-ci-debian-13]
+    needs: [run-ci-ubuntu-latest, run-ci-debian-11, run-ci-debian-12, run-ci-debian-13, run-enhanced-ci-debian-11]
     if: github.event.release
 
     steps:

--- a/ci/test_nspawn.sh
+++ b/ci/test_nspawn.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+
+sudo dpkg -i nsncd*.deb
+
+sudo useradd nsncdtest 
+
+
+sudo debootstrap --variant=minbase stable /stable-chroot http://deb.debian.org/debian/
+sdns="sudo systemd-nspawn -q --bind-ro /var/run/nscd/socket:/var/run/nscd/socket -D /stable-chroot"
+
+rc=0
+
+${sdns} getent passwd nsncdtest || rc=1
+${sdns} getent group nsncdtest || rc=1
+
+exit ${rc}


### PR DESCRIPTION
Simulate the use case where the nscd socket is mounted into a container.

Debootstrap a minimal debian install, start nsncd, run tests via systemd-nspawn with the socket mounted.