### PR TITLE
Getservbyport should refuse port 0

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -204,6 +204,11 @@ impl FromStr for ServiceWithPort {
 
 impl ServiceWithPort {
     fn lookup(&self) -> Result<Option<Service>> {
+        //issue-142
+        //port 0 lookups to sssd return ENOMEM
+        if self.port == 0 {
+            return Ok(None);
+        }
         let proto = match &self.proto {
             Some(p) => Some(CString::new(p.clone())?),
             None => None,


### PR DESCRIPTION
issue-142

If nsncd queries sssd for port 0, ENOMEM is returned causing error logs. This has been confirmed by using the getservbyport_r man page example and amending nsswitch.conf