### PR TITLE
Correctly handle lookups of missing netgroups

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -342,9 +342,9 @@ impl NetgroupWithName {
         };
 
         if unsafe { setnetgrent(netgroup_name.as_ptr() as *const c_char) } != 1 {
-            anyhow::bail!("Error: Could not open netgroup {}", self.name);
+            //setnetgrent returns 0 if the netgroup cannot be found
+            return Ok(results);
         }
-
         let mut buffer = vec![0 as c_char; 4096];
         let mut host: *mut c_char = std::ptr::null_mut();
         let mut user: *mut c_char = std::ptr::null_mut();


### PR DESCRIPTION
If the netgroup does not exist, setnetgrent returns 0. Do not bail, simply return 0 results