### PR TITLE
serialize_hostent: serialize IP addresses in one go

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -977,15 +977,11 @@ fn serialize_hostent(hostent: Hostent) -> Result<Vec<u8>> {
         match address {
             IpAddr::V4(ip4) => {
                 num_v4 += 1;
-                for octet in ip4.octets() {
-                    buf_addrs.push(octet)
-                }
+                buf_addrs.extend(ip4.octets())
             }
             IpAddr::V6(ip6) => {
                 num_v6 += 1;
-                for octet in ip6.octets() {
-                    buf_addrs.push(octet)
-                }
+                buf_addrs.extend(ip6.octets())
             }
         }
     }


### PR DESCRIPTION
Copying the IP adresses to the target addresses buffer in one go instead of copying them byte by byte.

We're already doing that for the getaddrinfo requests. It seems like we forgot to backport this to the legacy hostent operations.

I stumbled upon that while profiling a system doing a lot of gethostbyname requests. Nsncd was taking ~60% of the overall system load on it, mostly iterating on the IP adresses octets. The load is back to a more normal level once this diff is applied.