### PR TITLE
mark some tests little-endian only

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1297,6 +1297,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(target_endian = "little")]
     fn test_hostent_serialization() {
         let hostent = serialize_hostent(Hostent {
             name: CString::new(b"trantor.alternativebit.fr".to_vec()).unwrap(),
@@ -1419,6 +1420,7 @@ mod test {
     // unit tests of netgroup are a bit harder without /etc/netgroup data
 
     #[test]
+    #[cfg(target_endian = "little")]
     fn test_netgroup_serialization() {
         // validate netgroup response serialization
         let netgroupents = serialize_netgroup(vec![
@@ -1465,6 +1467,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(target_endian = "little")]
     fn test_innetgroup_serialization_in_group() {
         // validate innetgr serialization
         let in_netgroup = serialize_innetgr(true).expect("should serialize");


### PR DESCRIPTION
The wire format differs across target endianness, and these tests contain captures done on little endian, so they fail if executed on big endian, as the actual application code (rightfully) does produce something else.

Conditionalize them to only run on little endian. Another option would be to record another set of these from a big endian machine, and loop a big-endian machine into CI, but these aren't really available on GHA.

Fixes #160