### PR TITLE
GHA: bump upload-artifacts to @v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
           debian/rules vendor
           dpkg-buildpackage --no-sign
         working-directory: clone
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: deb-package-debian-11
           path: |
@@ -131,7 +131,7 @@ jobs:
           debian/rules vendor
           dpkg-buildpackage --no-sign
         working-directory: clone
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: deb-package-debian-12
           path: |
@@ -160,7 +160,7 @@ jobs:
           debian/rules vendor
           dpkg-buildpackage --no-sign
         working-directory: clone
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: deb-package-debian-13
           path: |


### PR DESCRIPTION
GHA currently fails with

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

So we need to bump this.

The failing clippy lint is fixed in https://github.com/twosigma/nsncd/pull/162.