### PR TITLE
Remove vendor rules target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,6 @@ jobs:
           toolchain: ${{ github.event.schedule && 'nightly' || 'stable' }}
       - name: Build package
         run: |
-          debian/rules vendor
           dpkg-buildpackage --no-sign
         working-directory: clone
       - uses: actions/upload-artifact@v4
@@ -128,7 +127,6 @@ jobs:
           toolchain: ${{ github.event.schedule && 'nightly' || 'stable' }}
       - name: Build package
         run: |
-          debian/rules vendor
           dpkg-buildpackage --no-sign
         working-directory: clone
       - uses: actions/upload-artifact@v4
@@ -157,7 +155,6 @@ jobs:
           toolchain: ${{ github.event.schedule && 'nightly' || 'stable' }}
       - name: Build package
         run: |
-          debian/rules vendor
           dpkg-buildpackage --no-sign
         working-directory: clone
       - uses: actions/upload-artifact@v4

--- a/debian/Cargo.toml.append
+++ b/debian/Cargo.toml.append
@@ -1,4 +1,0 @@
-
-
-[patch.crates-io]
-syn = { path = "vendor/syn" }

--- a/debian/README.source
+++ b/debian/README.source
@@ -1,21 +1,3 @@
-Because Debian Stretch does not have a complete Rust packaging
-environment yet, we build the Debian package by first using "cargo
-vendor" to download the dependencies. To run this automatically and set
-things up, manually run
+This build currently requires internet access to access crates.io
 
-    debian/rules vendor
-
-in an environment with internet accesss.
-
-You can commit the resulting changes to your local clone, if you build
-packages in CI from git sources, or you can build a source package. (You
-may want to first run "debian/rules build clean" to trigger a small
-change to Cargo.toml, too.) The resulting git repo / source package will
-build like an ordinary Debian package, without needing to access the
-internet.
-
-The "debian/rules vendor" target does the following:
- - Runs "cargo vendor" and sets up Cargo configuration
- - Works around an issue where the "syn" crate includes a .gitignore
-   file, which is automatically ignored by dpkg-source when building the
-   source package
+When debian 11 builds are retired, rust dependencies packaged by the distribution may be used.

--- a/debian/rules
+++ b/debian/rules
@@ -27,10 +27,3 @@ override_dh_auto_clean:
 override_dh_shlibdeps:
 	dh_shlibdeps
 	sed -i -e '/^shlibs:Depends=/s/, libc6 (\(<<\|>>\) [0-9\.]*)//g' debian/nsncd.substvars
-
-# See README.source.
-vendor:
-	mkdir -p .cargo
-	cargo vendor > .cargo/config
-	cat debian/Cargo.toml.append >> Cargo.toml
-	echo 'nsncd: source-is-missing vendor/*' > debian/source/lintian-overrides


### PR DESCRIPTION
Builds started to fail recently on all debian versions.

The closest reported issue I could find was on openwrt; related to a rustlang change, both are referenced below.

As we no longer build on debian 9 (minimum 11) - I removed the vendor rules target and special handling

https://github.com/openwrt/openwrt/issues/20189

https://github.com/rust-lang/cargo/commit/29ecb7f36a963bed4729bd6909200b4302a366a5