### PR TITLE
Harden the shipped systemd service

### DIFF
--- a/nsncd.service
+++ b/nsncd.service
@@ -17,7 +17,22 @@ Description=name-service non-caching daemon
 
 [Service]
 ExecStart=/usr/lib/nsncd
+# NSS modules may need host configuration, network access, and helper daemons.
+# Restrict kernel-facing interfaces without isolating those dependencies.
+CapabilityBoundingSet=
+LockPersonality=true
+PrivateDevices=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
 Restart=always
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+SystemCallFilter=~@clock @raw-io @reboot @swap
 Type=notify
 
 [Install]


### PR DESCRIPTION
## Summary
- empty the service capability bounding set and isolate kernel-facing interfaces that NSS modules should not need
- restrict namespace, realtime, personality, and alternate-ABI use while preserving host configuration, network access, and helper-daemon communication
- deny clock, raw-I/O, reboot, and swap syscall groups without changing service identity, filesystem visibility, or socket creation

Fixes #156

## Validation
- `git diff --check`
- reviewed the selected directives against the NSS compatibility constraints discussed in #156


## Remote Linux validation
- `git diff --check`
- `systemd-analyze verify nsncd.service`
