### PR TITLE
Reject invalid request key lengths before slicing

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -99,7 +99,10 @@ impl<'a> Request<'a> {
             .with_context(|| format!("invalid enum value {type_val}"))?;
 
         let key_len = buf[8..12].try_into().map(i32::from_ne_bytes)?;
-        let key_end = (12 + key_len).try_into()?;
+        let key_len: usize = key_len.try_into().context("invalid key length")?;
+        let key_end = 12usize
+            .checked_add(key_len)
+            .context("request key length overflow")?;
         ensure!(buf.len() >= key_end, "request body too small");
 
         Ok(Request {
@@ -327,6 +330,24 @@ impl NetgroupResponseHeader {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn request_with_key_len(key_len: i32) -> Vec<u8> {
+        let mut request = vec![];
+        request.extend_from_slice(&VERSION.to_ne_bytes());
+        request.extend_from_slice(&(RequestType::GETPWBYNAME as i32).to_ne_bytes());
+        request.extend_from_slice(&key_len.to_ne_bytes());
+        request
+    }
+
+    #[test]
+    fn request_parse_rejects_negative_key_len() {
+        assert!(Request::parse(&request_with_key_len(-1)).is_err());
+    }
+
+    #[test]
+    fn request_parse_rejects_oversized_key_len() {
+        assert!(Request::parse(&request_with_key_len(i32::MAX)).is_err());
+    }
 
     #[test]
     fn test_pw_response_header_as_slice() {


### PR DESCRIPTION
## Summary

- convert the signed protocol key length to `usize` before offset arithmetic
- reject negative and overflowing request key lengths as parser errors
- add regressions for negative and oversized wire lengths

The socket protocol carries `key_len` as an `i32`. Previously, values from `-1` through `-12` produced an end offset before the key start and then panicked while slicing. Large values could also overflow the signed addition in checked builds. Since the daemon socket is intentionally available to local clients, malformed requests should be rejected without taking down a worker.

## Validation

- `git diff --check`
- `rustfmt --edition 2018 --check src/protocol.rs`

## Remote Linux validation
- `git diff --check`
- `rustfmt --edition 2018 --check src/protocol.rs`
- `cargo test` (31 passed, 1 ignored)
- `cargo clippy --bins --tests -- -D warnings`
