### PR TITLE
Harden nsncd.service

### DIFF
--- a/nsncd.service
+++ b/nsncd.service
@@ -17,7 +17,24 @@ Description=name-service non-caching daemon
 
 [Service]
 ExecStart=/usr/lib/nsncd
+# NSS modules may read host configuration, open network connections, or talk to
+# local daemons. Do not isolate those interfaces here.
+CapabilityBoundingSet=
+LockPersonality=true
+NoNewPrivileges=true
+PrivateDevices=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
 Restart=always
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+SystemCallFilter=~@clock @raw-io @reboot @swap
 Type=notify
 
 [Install]


### PR DESCRIPTION
## Summary

Add a conservative set of systemd sandboxing directives to `nsncd.service`. The service now runs without capabilities, cannot acquire new privileges, and cannot create namespaces or use realtime scheduling. It is also limited to the native ABI and denied clock-setting, raw-I/O, reboot, and swap system calls.

NSS modules may depend on host configuration, network access, process information, shared temporary files, or local daemons. This change leaves those interfaces available: it does not set `PrivateNetwork=`, `RestrictAddressFamilies=`, `ProtectSystem=`, `ProtectHome=`, `ProtectProc=`, or `PrivateTmp=`.

Fixes #156.

## Validation

- `git diff --check`
- `cargo test --locked` — 31 passed, 0 failed, 1 ignored
- `cargo build --release --locked`
- `systemd-analyze verify nsncd.service` with systemd 252 and 255
- `systemd-analyze security --offline=yes nsncd.service` with systemd 255 — exposure reduced from 9.4 UNSAFE to 3.6 OK
- started the service under systemd 252 and confirmed that it became active, created `/var/run/nscd/socket`, and served passwd, group, and hosts lookups through `getent`
